### PR TITLE
fix: Amazon scraper - resolve 503 bot detection and broken selectors

### DIFF
--- a/backend/selectors.json
+++ b/backend/selectors.json
@@ -1,7 +1,7 @@
 {
   "amazon": {
     "product_wrapper": "div[data-component-type='s-search-result']",
-    "title": "h2 a span",
+    "title": "h2 a",
     "price": ".a-price-whole",
     "link": "h2 a"
   },

--- a/backend/src/main/java/com/pricetracker/engine/WebDriverFactory.java
+++ b/backend/src/main/java/com/pricetracker/engine/WebDriverFactory.java
@@ -12,9 +12,10 @@ import java.util.Random;
 public class WebDriverFactory {
 
     private static final String[] USER_AGENTS = {
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
     };
 
     public static WebDriver createStealthDriver() {

--- a/backend/src/main/java/com/pricetracker/scrapers/AmazonScraper.java
+++ b/backend/src/main/java/com/pricetracker/scrapers/AmazonScraper.java
@@ -29,66 +29,98 @@ public class AmazonScraper implements ScraperCallable {
         try {
             // 1. Setup Stealth Driver
             driver = com.pricetracker.engine.WebDriverFactory.createStealthDriver();
-            WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(15));
+            WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(20));
 
-            // 2. Navigate to Amazon
+            // 2. Visit homepage first to establish cookies and avoid 503 bot detection
+            driver.get("https://www.amazon.in/");
+            Thread.sleep(1500 + new java.util.Random().nextInt(1500));
+
+            // 3. Navigate to search URL
             String encodedQuery = URLEncoder.encode(keyword, StandardCharsets.UTF_8);
             String url = "https://www.amazon.in/s?k=" + encodedQuery;
-            
-            // Random delay to mimic human behavior
-            Thread.sleep(1000 + new java.util.Random().nextInt(2000));
-            
             driver.get(url);
 
-            // 3. Wait for products to load with diagnostics
+            // 4. Wait for products to load with fallback selectors
             String wrapperSelector = SelectorConfig.get("amazon", "product_wrapper");
+            // Add fallback selector in case the primary one doesn't work
+            String combinedWrapper = wrapperSelector + ", .s-result-item[data-asin]:not([data-asin=''])";
+            
             try {
-                wait.until(ExpectedConditions.presenceOfElementLocated(By.cssSelector(wrapperSelector)));
+                wait.until(ExpectedConditions.presenceOfElementLocated(By.cssSelector(combinedWrapper)));
             } catch (Exception e) {
                 System.err.println("[Amazon] Failed to find results. Page Title: " + driver.getTitle());
                 System.err.println("[Amazon] URL: " + driver.getCurrentUrl());
-                // Optional: Print a bit of page source for debugging
                 String source = driver.getPageSource();
                 if (source.contains("captcha") || source.contains("Robot Check")) {
                     System.err.println("[Amazon] Bot detection triggered!");
+                } else if (source.contains("503") || source.contains("Service Unavailable")) {
+                    System.err.println("[Amazon] 503 Service Unavailable - blocked by Amazon!");
                 }
                 throw e;
             }
 
-            WebElement firstResult = driver.findElement(By.cssSelector(wrapperSelector));
+            // 5. Get all matching result elements and iterate to find a valid one
+            java.util.List<WebElement> results = driver.findElements(By.cssSelector(combinedWrapper));
             
-            if (firstResult != null) {
-                // Title
-                String title = "Unknown Amazon Product";
-                try {
-                    WebElement titleEl = firstResult.findElement(By.cssSelector("h2"));
-                    title = titleEl.getText();
-                } catch (Exception e) {
-                    // Ignore missing title
-                }
+            String titleSelector = SelectorConfig.get("amazon", "title");
+            String priceSelector = SelectorConfig.get("amazon", "price");
+            String linkSelector = SelectorConfig.get("amazon", "link");
 
-                // Price
-                String priceSelector = SelectorConfig.get("amazon", "price");
-                double price = Double.MAX_VALUE;
+            for (WebElement result : results) {
                 try {
-                    String priceText = firstResult.findElement(By.cssSelector(priceSelector)).getText().replaceAll("[^0-9.]", "");
-                    if (!priceText.isEmpty()) {
-                        price = Double.parseDouble(priceText);
+                    // Title
+                    String title;
+                    try {
+                        title = result.findElement(By.cssSelector(titleSelector)).getText().trim();
+                    } catch (Exception e) {
+                        // Fallback: try h2 span
+                        try {
+                            title = result.findElement(By.cssSelector("h2 span")).getText().trim();
+                        } catch (Exception e2) {
+                            continue; // Skip this result, no title found
+                        }
                     }
-                } catch (Exception e) {
-                    // Ignore price parsing errors
-                }
+                    if (title.isEmpty()) continue;
 
-                // Link
-                String productLink = url;
-                try {
-                    WebElement linkEl = firstResult.findElement(By.cssSelector("h2 a"));
-                    productLink = linkEl.getAttribute("href");
-                } catch (Exception e) {
-                    // Ignore link retrieval errors
-                }
+                    // Price
+                    double price = Double.MAX_VALUE;
+                    try {
+                        String priceText = result.findElement(By.cssSelector(priceSelector))
+                                .getText().replaceAll("[^0-9.]", "");
+                        if (!priceText.isEmpty()) {
+                            price = Double.parseDouble(priceText);
+                        }
+                    } catch (Exception e) {
+                        // Try fallback price selectors
+                        try {
+                            String priceText = result.findElement(By.cssSelector(".a-price .a-offscreen"))
+                                    .getAttribute("textContent").replaceAll("[^0-9.]", "");
+                            if (!priceText.isEmpty()) {
+                                price = Double.parseDouble(priceText);
+                            }
+                        } catch (Exception e2) {
+                            continue; // Skip result without price
+                        }
+                    }
+                    if (price == Double.MAX_VALUE) continue;
 
-                return new Product(title, price, "Amazon", productLink);
+                    // Link
+                    String productLink = url;
+                    try {
+                        WebElement linkEl = result.findElement(By.cssSelector(linkSelector));
+                        String href = linkEl.getAttribute("href");
+                        if (href != null && !href.isEmpty()) {
+                            productLink = href;
+                        }
+                    } catch (Exception e) {
+                        // Keep the search URL as fallback
+                    }
+
+                    return new Product(title, price, "Amazon", productLink);
+                } catch (Exception e) {
+                    // This result failed, try the next one
+                    continue;
+                }
             }
 
         } catch (Exception e) {


### PR DESCRIPTION
- Visit amazon.in homepage first to establish cookies/session before search
- Use dynamic selectors from selectors.json instead of hardcoded h2/h2 a
- Add fallback wrapper and price selectors for resilience
- Iterate through results to find valid product instead of crashing on first
- Update User-Agent strings to modern Chrome 125/126
- Fix title selector from 'h2 a span' to 'h2 a' for full product names

### Description
Detailed description of the changes made.

### Related Issue
Fixes #[issue number]

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

### Screenshots (if applicable)
Add screenshots to help explain your PR.
