### PR TITLE
build: add .dockerignore for backend

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,6 @@
+target/
+price_history.db
+*.log
+.idea/
+*.iml
+.vscode/


### PR DESCRIPTION
Adds a \.dockerignore\ to exclude build artifacts, the SQLite database, logs, and IDE files from the Docker context.

This reduces the build context size and prevents stale artifacts from being packaged.