### PR TITLE
test: add unit tests for Product and SelectorConfig

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -41,7 +41,7 @@
         <!-- Unit Testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <version>6.1.2</version>
             <scope>test</scope>
         </dependency>
@@ -84,6 +84,12 @@
 
     <build>
         <plugins>
+            <!-- Maven Surefire Plugin for running tests -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.3</version>
+            </plugin>
             <!-- Maven Assembly Plugin to create a Fat JAR with dependencies -->
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/backend/src/test/java/com/pricetracker/engine/SelectorConfigTest.java
+++ b/backend/src/test/java/com/pricetracker/engine/SelectorConfigTest.java
@@ -1,0 +1,26 @@
+package com.pricetracker.engine;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SelectorConfigTest {
+
+    @Test
+    void getReturnsSelectorForKnownSiteAndField() {
+        String selector = SelectorConfig.get("amazon", "container");
+        assertNotNull(selector);
+        assertFalse(selector.isEmpty());
+    }
+
+    @Test
+    void getReturnsEmptyForUnknownSite() {
+        String selector = SelectorConfig.get("unknownSite", "container");
+        assertEquals("", selector);
+    }
+
+    @Test
+    void getReturnsEmptyForUnknownField() {
+        String selector = SelectorConfig.get("amazon", "nonexistentField");
+        assertEquals("", selector);
+    }
+}

--- a/backend/src/test/java/com/pricetracker/engine/SelectorConfigTest.java
+++ b/backend/src/test/java/com/pricetracker/engine/SelectorConfigTest.java
@@ -7,7 +7,7 @@ class SelectorConfigTest {
 
     @Test
     void getReturnsSelectorForKnownSiteAndField() {
-        String selector = SelectorConfig.get("amazon", "container");
+        String selector = SelectorConfig.get("amazon", "title");
         assertNotNull(selector);
         assertFalse(selector.isEmpty());
     }

--- a/backend/src/test/java/com/pricetracker/model/ProductTest.java
+++ b/backend/src/test/java/com/pricetracker/model/ProductTest.java
@@ -1,0 +1,44 @@
+package com.pricetracker.model;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProductTest {
+
+    @Test
+    void constructorSetsFields() {
+        Product p = new Product("iPhone 15", 79999.0, "Amazon", "https://amazon.in/dp/xyz");
+        assertEquals("iPhone 15", p.getName());
+        assertEquals(79999.0, p.getPrice());
+        assertEquals("Amazon", p.getPlatform());
+        assertEquals("https://amazon.in/dp/xyz", p.getUrl());
+    }
+
+    @Test
+    void compareToSortsByPriceAscending() {
+        Product cheap = new Product("A", 100.0, "S1", "u1");
+        Product expensive = new Product("B", 200.0, "S2", "u2");
+        assertTrue(cheap.compareTo(expensive) < 0);
+        assertTrue(expensive.compareTo(cheap) > 0);
+        assertEquals(0, cheap.compareTo(cheap));
+    }
+
+    @Test
+    void toJSONContainsAllFields() {
+        Product p = new Product("Test Product", 500.0, "Flipkart", "https://flipkart.com/p");
+        var json = p.toJSON();
+        assertEquals("Test Product", json.getString("name"));
+        assertEquals(500.0, json.getDouble("price"));
+        assertEquals("Flipkart", json.getString("platform"));
+        assertEquals("https://flipkart.com/p", json.getString("url"));
+    }
+
+    @Test
+    void toStringContainsPlatformNameAndPrice() {
+        Product p = new Product("Pixel 8", 69999.0, "Croma", "https://croma.com/p");
+        String s = p.toString();
+        assertTrue(s.contains("Croma"));
+        assertTrue(s.contains("Pixel 8"));
+        assertTrue(s.contains("69999.0"));
+    }
+}


### PR DESCRIPTION
Adds initial unit test suite with JUnit 5:\n- ProductTest: constructor, compareTo, toJSON, toString\n- SelectorConfigTest: selector lookup for known/unknown sites and fields\n\nAlso updates pom.xml to use junit-jupiter aggregator artifact and adds maven-surefire-plugin.