### PR TITLE
build: add docker-compose for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "7860:7860"
+    environment:
+      - PORT=7860
+    volumes:
+      - ./backend/price_history.db:/app/price_history.db
+      - ./backend/selectors.json:/app/selectors.json
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:7860/api/health"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 10s


### PR DESCRIPTION
Adds a docker-compose.yml for running the backend with a single command. Mounts the SQLite database and selectors.json as volumes for persistence and configuration.