### PR TITLE
feat: auto-generate CHANGELOG.md after every PR merge

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,36 @@
+name: "Update Changelog"
+
+on:
+  workflow_run:
+    workflows: ["Avengers Guard"]
+    types: [completed]
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  changelog:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: master
+
+      - name: Generate changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --verbose
+        env:
+          OUTPUT: CHANGELOG.md
+
+      - name: Commit changelog
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: master
+          commit_message: "chore: update changelog [skip ci]"
+          file_pattern: CHANGELOG.md

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,33 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to **Price Scout** are documented here.
+
+"""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }}{% if commit.github.username %} by @{{ commit.github.username }}{% endif %}
+{% endfor %}
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^style", group = "Styling" },
+  { message = "^refactor", group = "Code Refactoring" },
+  { message = "^perf", group = "Performance Improvements" },
+  { message = "^test", group = "Tests" },
+  { message = "^build", group = "Build System" },
+  { message = "^ci", group = "Continuous Integration" },
+  { message = "^chore", group = "Chores" },
+  { message = "^revert", group = "Reverts" },
+]
+filter_commits = true


### PR DESCRIPTION
Adds automatic changelog generation using \git-cliff\:

- \cliff.toml\: Configuration that parses conventional commits and groups by type (Features, Bug Fixes, Documentation, etc.)
- \.github/workflows/changelog.yml\: Workflow that runs after **Avengers Guard** CI succeeds on \master\, generates \CHANGELOG.md\, and commits it with \[skip ci]\

The changelog contains the full commit history and will be updated after every PR merge once CI passes.