### PR TITLE
fix: set git identity before committing changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -39,6 +39,9 @@ jobs:
             exit 0
           fi
 
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
           BRANCH="auto-changelog"
           git checkout -b "$BRANCH"
           git add CHANGELOG.md


### PR DESCRIPTION
Adds git user.name/user.email config so the changelog commit doesn't fail with 'Author identity unknown'.

Also adds \PAT_TOKEN\ secret support - the workflow will use a PAT if available (bypasses the 'not permitted to create PRs' restriction from \GITHUB_TOKEN\).